### PR TITLE
Update libetebase to 0.5.0

### DIFF
--- a/libetebase-cargo-sources.json
+++ b/libetebase-cargo-sources.json
@@ -1,10 +1,10 @@
 [
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ansi_term/ansi_term-0.11.0.crate",
         "sha256": "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b",
-        "dest": "cargo/vendor",
-        "dest-filename": "ansi_term-0.11.0.crate"
+        "dest": "cargo/vendor/ansi_term-0.11.0"
     },
     {
         "type": "file",
@@ -13,11 +13,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/atty/atty-0.2.14.crate",
         "sha256": "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
-        "dest": "cargo/vendor",
-        "dest-filename": "atty-0.2.14.crate"
+        "dest": "cargo/vendor/atty-0.2.14"
     },
     {
         "type": "file",
@@ -26,11 +26,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/autocfg/autocfg-1.0.0.crate",
         "sha256": "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d",
-        "dest": "cargo/vendor",
-        "dest-filename": "autocfg-1.0.0.crate"
+        "dest": "cargo/vendor/autocfg-1.0.0"
     },
     {
         "type": "file",
@@ -39,11 +39,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/base64/base64-0.12.3.crate",
         "sha256": "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff",
-        "dest": "cargo/vendor",
-        "dest-filename": "base64-0.12.3.crate"
+        "dest": "cargo/vendor/base64-0.12.3"
     },
     {
         "type": "file",
@@ -52,11 +52,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bitflags/bitflags-1.2.1.crate",
         "sha256": "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693",
-        "dest": "cargo/vendor",
-        "dest-filename": "bitflags-1.2.1.crate"
+        "dest": "cargo/vendor/bitflags-1.2.1"
     },
     {
         "type": "file",
@@ -65,11 +65,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.4.0.crate",
         "sha256": "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820",
-        "dest": "cargo/vendor",
-        "dest-filename": "bumpalo-3.4.0.crate"
+        "dest": "cargo/vendor/bumpalo-3.4.0"
     },
     {
         "type": "file",
@@ -78,11 +78,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/byteorder/byteorder-1.3.4.crate",
         "sha256": "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de",
-        "dest": "cargo/vendor",
-        "dest-filename": "byteorder-1.3.4.crate"
+        "dest": "cargo/vendor/byteorder-1.3.4"
     },
     {
         "type": "file",
@@ -91,11 +91,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bytes/bytes-0.5.6.crate",
         "sha256": "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38",
-        "dest": "cargo/vendor",
-        "dest-filename": "bytes-0.5.6.crate"
+        "dest": "cargo/vendor/bytes-0.5.6"
     },
     {
         "type": "file",
@@ -104,11 +104,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cbindgen/cbindgen-0.14.4.crate",
         "sha256": "e783d38a7700989e0209d0b0ed224c34ade92d3603da0cf15dc502ebada685a6",
-        "dest": "cargo/vendor",
-        "dest-filename": "cbindgen-0.14.4.crate"
+        "dest": "cargo/vendor/cbindgen-0.14.4"
     },
     {
         "type": "file",
@@ -117,11 +117,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cc/cc-1.0.58.crate",
         "sha256": "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518",
-        "dest": "cargo/vendor",
-        "dest-filename": "cc-1.0.58.crate"
+        "dest": "cargo/vendor/cc-1.0.58"
     },
     {
         "type": "file",
@@ -130,11 +130,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cfg-if/cfg-if-0.1.10.crate",
         "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
-        "dest": "cargo/vendor",
-        "dest-filename": "cfg-if-0.1.10.crate"
+        "dest": "cargo/vendor/cfg-if-0.1.10"
     },
     {
         "type": "file",
@@ -143,11 +143,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clap/clap-2.33.3.crate",
         "sha256": "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002",
-        "dest": "cargo/vendor",
-        "dest-filename": "clap-2.33.3.crate"
+        "dest": "cargo/vendor/clap-2.33.3"
     },
     {
         "type": "file",
@@ -156,11 +156,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.7.0.crate",
         "sha256": "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-foundation-0.7.0.crate"
+        "dest": "cargo/vendor/core-foundation-0.7.0"
     },
     {
         "type": "file",
@@ -169,11 +169,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.7.0.crate",
         "sha256": "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-foundation-sys-0.7.0.crate"
+        "dest": "cargo/vendor/core-foundation-sys-0.7.0"
     },
     {
         "type": "file",
@@ -182,11 +182,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.4.4.crate",
         "sha256": "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87",
-        "dest": "cargo/vendor",
-        "dest-filename": "crossbeam-channel-0.4.4.crate"
+        "dest": "cargo/vendor/crossbeam-channel-0.4.4"
     },
     {
         "type": "file",
@@ -195,11 +195,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.7.3.crate",
         "sha256": "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285",
-        "dest": "cargo/vendor",
-        "dest-filename": "crossbeam-deque-0.7.3.crate"
+        "dest": "cargo/vendor/crossbeam-deque-0.7.3"
     },
     {
         "type": "file",
@@ -208,11 +208,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.8.2.crate",
         "sha256": "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace",
-        "dest": "cargo/vendor",
-        "dest-filename": "crossbeam-epoch-0.8.2.crate"
+        "dest": "cargo/vendor/crossbeam-epoch-0.8.2"
     },
     {
         "type": "file",
@@ -221,11 +221,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.7.2.crate",
         "sha256": "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8",
-        "dest": "cargo/vendor",
-        "dest-filename": "crossbeam-utils-0.7.2.crate"
+        "dest": "cargo/vendor/crossbeam-utils-0.7.2"
     },
     {
         "type": "file",
@@ -234,11 +234,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dtoa/dtoa-0.4.6.crate",
         "sha256": "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b",
-        "dest": "cargo/vendor",
-        "dest-filename": "dtoa-0.4.6.crate"
+        "dest": "cargo/vendor/dtoa-0.4.6"
     },
     {
         "type": "file",
@@ -247,11 +247,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/either/either-1.6.1.crate",
         "sha256": "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457",
-        "dest": "cargo/vendor",
-        "dest-filename": "either-1.6.1.crate"
+        "dest": "cargo/vendor/either-1.6.1"
     },
     {
         "type": "file",
@@ -260,11 +260,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.23.crate",
         "sha256": "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171",
-        "dest": "cargo/vendor",
-        "dest-filename": "encoding_rs-0.8.23.crate"
+        "dest": "cargo/vendor/encoding_rs-0.8.23"
     },
     {
         "type": "file",
@@ -275,7 +275,7 @@
     {
         "type": "git",
         "url": "https://github.com/etesync/etebase-rs",
-        "commit": "b3aad3e01fd602f3547e0af82d3bf1b5701b79a2",
+        "commit": "a56a3bac2c056b957cbb5d81e1f70815da66bd9a",
         "dest": "cargo/vendor/etebase"
     },
     {
@@ -285,11 +285,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fnv/fnv-1.0.7.crate",
         "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
-        "dest": "cargo/vendor",
-        "dest-filename": "fnv-1.0.7.crate"
+        "dest": "cargo/vendor/fnv-1.0.7"
     },
     {
         "type": "file",
@@ -298,11 +298,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.3.2.crate",
         "sha256": "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1",
-        "dest": "cargo/vendor",
-        "dest-filename": "foreign-types-0.3.2.crate"
+        "dest": "cargo/vendor/foreign-types-0.3.2"
     },
     {
         "type": "file",
@@ -311,11 +311,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.1.1.crate",
         "sha256": "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b",
-        "dest": "cargo/vendor",
-        "dest-filename": "foreign-types-shared-0.1.1.crate"
+        "dest": "cargo/vendor/foreign-types-shared-0.1.1"
     },
     {
         "type": "file",
@@ -324,11 +324,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fuchsia-zircon/fuchsia-zircon-0.3.3.crate",
         "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
-        "dest": "cargo/vendor",
-        "dest-filename": "fuchsia-zircon-0.3.3.crate"
+        "dest": "cargo/vendor/fuchsia-zircon-0.3.3"
     },
     {
         "type": "file",
@@ -337,11 +337,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fuchsia-zircon-sys/fuchsia-zircon-sys-0.3.3.crate",
         "sha256": "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7",
-        "dest": "cargo/vendor",
-        "dest-filename": "fuchsia-zircon-sys-0.3.3.crate"
+        "dest": "cargo/vendor/fuchsia-zircon-sys-0.3.3"
     },
     {
         "type": "file",
@@ -350,11 +350,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.5.crate",
         "sha256": "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-channel-0.3.5.crate"
+        "dest": "cargo/vendor/futures-channel-0.3.5"
     },
     {
         "type": "file",
@@ -363,11 +363,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.5.crate",
         "sha256": "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-core-0.3.5.crate"
+        "dest": "cargo/vendor/futures-core-0.3.5"
     },
     {
         "type": "file",
@@ -376,11 +376,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.5.crate",
         "sha256": "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-io-0.3.5.crate"
+        "dest": "cargo/vendor/futures-io-0.3.5"
     },
     {
         "type": "file",
@@ -389,11 +389,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.5.crate",
         "sha256": "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-sink-0.3.5.crate"
+        "dest": "cargo/vendor/futures-sink-0.3.5"
     },
     {
         "type": "file",
@@ -402,11 +402,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.5.crate",
         "sha256": "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-task-0.3.5.crate"
+        "dest": "cargo/vendor/futures-task-0.3.5"
     },
     {
         "type": "file",
@@ -415,11 +415,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.5.crate",
         "sha256": "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-util-0.3.5.crate"
+        "dest": "cargo/vendor/futures-util-0.3.5"
     },
     {
         "type": "file",
@@ -428,11 +428,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/getrandom/getrandom-0.1.14.crate",
         "sha256": "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb",
-        "dest": "cargo/vendor",
-        "dest-filename": "getrandom-0.1.14.crate"
+        "dest": "cargo/vendor/getrandom-0.1.14"
     },
     {
         "type": "file",
@@ -441,11 +441,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/h2/h2-0.2.6.crate",
         "sha256": "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53",
-        "dest": "cargo/vendor",
-        "dest-filename": "h2-0.2.6.crate"
+        "dest": "cargo/vendor/h2-0.2.6"
     },
     {
         "type": "file",
@@ -454,11 +454,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.8.1.crate",
         "sha256": "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb",
-        "dest": "cargo/vendor",
-        "dest-filename": "hashbrown-0.8.1.crate"
+        "dest": "cargo/vendor/hashbrown-0.8.1"
     },
     {
         "type": "file",
@@ -467,11 +467,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/heck/heck-0.3.1.crate",
         "sha256": "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205",
-        "dest": "cargo/vendor",
-        "dest-filename": "heck-0.3.1.crate"
+        "dest": "cargo/vendor/heck-0.3.1"
     },
     {
         "type": "file",
@@ -480,11 +480,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.1.15.crate",
         "sha256": "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9",
-        "dest": "cargo/vendor",
-        "dest-filename": "hermit-abi-0.1.15.crate"
+        "dest": "cargo/vendor/hermit-abi-0.1.15"
     },
     {
         "type": "file",
@@ -493,11 +493,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/http/http-0.2.1.crate",
         "sha256": "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9",
-        "dest": "cargo/vendor",
-        "dest-filename": "http-0.2.1.crate"
+        "dest": "cargo/vendor/http-0.2.1"
     },
     {
         "type": "file",
@@ -506,11 +506,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/http-body/http-body-0.3.1.crate",
         "sha256": "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b",
-        "dest": "cargo/vendor",
-        "dest-filename": "http-body-0.3.1.crate"
+        "dest": "cargo/vendor/http-body-0.3.1"
     },
     {
         "type": "file",
@@ -519,11 +519,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/httparse/httparse-1.3.4.crate",
         "sha256": "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9",
-        "dest": "cargo/vendor",
-        "dest-filename": "httparse-1.3.4.crate"
+        "dest": "cargo/vendor/httparse-1.3.4"
     },
     {
         "type": "file",
@@ -532,11 +532,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hyper/hyper-0.13.7.crate",
         "sha256": "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb",
-        "dest": "cargo/vendor",
-        "dest-filename": "hyper-0.13.7.crate"
+        "dest": "cargo/vendor/hyper-0.13.7"
     },
     {
         "type": "file",
@@ -545,11 +545,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hyper-tls/hyper-tls-0.4.3.crate",
         "sha256": "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed",
-        "dest": "cargo/vendor",
-        "dest-filename": "hyper-tls-0.4.3.crate"
+        "dest": "cargo/vendor/hyper-tls-0.4.3"
     },
     {
         "type": "file",
@@ -558,11 +558,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/idna/idna-0.2.0.crate",
         "sha256": "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9",
-        "dest": "cargo/vendor",
-        "dest-filename": "idna-0.2.0.crate"
+        "dest": "cargo/vendor/idna-0.2.0"
     },
     {
         "type": "file",
@@ -571,11 +571,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/indexmap/indexmap-1.5.0.crate",
         "sha256": "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7",
-        "dest": "cargo/vendor",
-        "dest-filename": "indexmap-1.5.0.crate"
+        "dest": "cargo/vendor/indexmap-1.5.0"
     },
     {
         "type": "file",
@@ -584,11 +584,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iovec/iovec-0.1.4.crate",
         "sha256": "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e",
-        "dest": "cargo/vendor",
-        "dest-filename": "iovec-0.1.4.crate"
+        "dest": "cargo/vendor/iovec-0.1.4"
     },
     {
         "type": "file",
@@ -597,11 +597,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ipnet/ipnet-2.3.0.crate",
         "sha256": "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135",
-        "dest": "cargo/vendor",
-        "dest-filename": "ipnet-2.3.0.crate"
+        "dest": "cargo/vendor/ipnet-2.3.0"
     },
     {
         "type": "file",
@@ -610,11 +610,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/itoa/itoa-0.4.6.crate",
         "sha256": "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6",
-        "dest": "cargo/vendor",
-        "dest-filename": "itoa-0.4.6.crate"
+        "dest": "cargo/vendor/itoa-0.4.6"
     },
     {
         "type": "file",
@@ -623,11 +623,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.42.crate",
         "sha256": "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2",
-        "dest": "cargo/vendor",
-        "dest-filename": "js-sys-0.3.42.crate"
+        "dest": "cargo/vendor/js-sys-0.3.42"
     },
     {
         "type": "file",
@@ -636,11 +636,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/kernel32-sys/kernel32-sys-0.2.2.crate",
         "sha256": "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d",
-        "dest": "cargo/vendor",
-        "dest-filename": "kernel32-sys-0.2.2.crate"
+        "dest": "cargo/vendor/kernel32-sys-0.2.2"
     },
     {
         "type": "file",
@@ -649,11 +649,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.4.0.crate",
         "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
-        "dest": "cargo/vendor",
-        "dest-filename": "lazy_static-1.4.0.crate"
+        "dest": "cargo/vendor/lazy_static-1.4.0"
     },
     {
         "type": "file",
@@ -662,11 +662,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libc/libc-0.2.73.crate",
         "sha256": "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9",
-        "dest": "cargo/vendor",
-        "dest-filename": "libc-0.2.73.crate"
+        "dest": "cargo/vendor/libc-0.2.73"
     },
     {
         "type": "file",
@@ -675,11 +675,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libsodium-sys/libsodium-sys-0.2.6.crate",
         "sha256": "a685b64f837b339074115f2e7f7b431ac73681d08d75b389db7498b8892b8a58",
-        "dest": "cargo/vendor",
-        "dest-filename": "libsodium-sys-0.2.6.crate"
+        "dest": "cargo/vendor/libsodium-sys-0.2.6"
     },
     {
         "type": "file",
@@ -688,11 +688,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/log/log-0.4.11.crate",
         "sha256": "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b",
-        "dest": "cargo/vendor",
-        "dest-filename": "log-0.4.11.crate"
+        "dest": "cargo/vendor/log-0.4.11"
     },
     {
         "type": "file",
@@ -701,11 +701,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/matches/matches-0.1.8.crate",
         "sha256": "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08",
-        "dest": "cargo/vendor",
-        "dest-filename": "matches-0.1.8.crate"
+        "dest": "cargo/vendor/matches-0.1.8"
     },
     {
         "type": "file",
@@ -714,11 +714,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/maybe-uninit/maybe-uninit-2.0.0.crate",
         "sha256": "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00",
-        "dest": "cargo/vendor",
-        "dest-filename": "maybe-uninit-2.0.0.crate"
+        "dest": "cargo/vendor/maybe-uninit-2.0.0"
     },
     {
         "type": "file",
@@ -727,11 +727,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/memchr/memchr-2.3.3.crate",
         "sha256": "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400",
-        "dest": "cargo/vendor",
-        "dest-filename": "memchr-2.3.3.crate"
+        "dest": "cargo/vendor/memchr-2.3.3"
     },
     {
         "type": "file",
@@ -740,11 +740,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/memoffset/memoffset-0.5.6.crate",
         "sha256": "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa",
-        "dest": "cargo/vendor",
-        "dest-filename": "memoffset-0.5.6.crate"
+        "dest": "cargo/vendor/memoffset-0.5.6"
     },
     {
         "type": "file",
@@ -753,11 +753,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/mime/mime-0.3.16.crate",
         "sha256": "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d",
-        "dest": "cargo/vendor",
-        "dest-filename": "mime-0.3.16.crate"
+        "dest": "cargo/vendor/mime-0.3.16"
     },
     {
         "type": "file",
@@ -766,11 +766,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/mime_guess/mime_guess-2.0.3.crate",
         "sha256": "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212",
-        "dest": "cargo/vendor",
-        "dest-filename": "mime_guess-2.0.3.crate"
+        "dest": "cargo/vendor/mime_guess-2.0.3"
     },
     {
         "type": "file",
@@ -779,11 +779,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/mio/mio-0.6.22.crate",
         "sha256": "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430",
-        "dest": "cargo/vendor",
-        "dest-filename": "mio-0.6.22.crate"
+        "dest": "cargo/vendor/mio-0.6.22"
     },
     {
         "type": "file",
@@ -792,11 +792,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/miow/miow-0.2.1.crate",
         "sha256": "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919",
-        "dest": "cargo/vendor",
-        "dest-filename": "miow-0.2.1.crate"
+        "dest": "cargo/vendor/miow-0.2.1"
     },
     {
         "type": "file",
@@ -805,11 +805,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/native-tls/native-tls-0.2.4.crate",
         "sha256": "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d",
-        "dest": "cargo/vendor",
-        "dest-filename": "native-tls-0.2.4.crate"
+        "dest": "cargo/vendor/native-tls-0.2.4"
     },
     {
         "type": "file",
@@ -818,11 +818,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/net2/net2-0.2.34.crate",
         "sha256": "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7",
-        "dest": "cargo/vendor",
-        "dest-filename": "net2-0.2.34.crate"
+        "dest": "cargo/vendor/net2-0.2.34"
     },
     {
         "type": "file",
@@ -831,11 +831,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.12.crate",
         "sha256": "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611",
-        "dest": "cargo/vendor",
-        "dest-filename": "num-traits-0.2.12.crate"
+        "dest": "cargo/vendor/num-traits-0.2.12"
     },
     {
         "type": "file",
@@ -844,11 +844,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num_cpus/num_cpus-1.13.0.crate",
         "sha256": "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3",
-        "dest": "cargo/vendor",
-        "dest-filename": "num_cpus-1.13.0.crate"
+        "dest": "cargo/vendor/num_cpus-1.13.0"
     },
     {
         "type": "file",
@@ -857,11 +857,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/once_cell/once_cell-1.4.0.crate",
         "sha256": "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d",
-        "dest": "cargo/vendor",
-        "dest-filename": "once_cell-1.4.0.crate"
+        "dest": "cargo/vendor/once_cell-1.4.0"
     },
     {
         "type": "file",
@@ -870,11 +870,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/openssl/openssl-0.10.30.crate",
         "sha256": "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4",
-        "dest": "cargo/vendor",
-        "dest-filename": "openssl-0.10.30.crate"
+        "dest": "cargo/vendor/openssl-0.10.30"
     },
     {
         "type": "file",
@@ -883,11 +883,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/openssl-probe/openssl-probe-0.1.2.crate",
         "sha256": "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de",
-        "dest": "cargo/vendor",
-        "dest-filename": "openssl-probe-0.1.2.crate"
+        "dest": "cargo/vendor/openssl-probe-0.1.2"
     },
     {
         "type": "file",
@@ -896,11 +896,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.58.crate",
         "sha256": "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de",
-        "dest": "cargo/vendor",
-        "dest-filename": "openssl-sys-0.9.58.crate"
+        "dest": "cargo/vendor/openssl-sys-0.9.58"
     },
     {
         "type": "file",
@@ -909,11 +909,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.1.0.crate",
         "sha256": "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e",
-        "dest": "cargo/vendor",
-        "dest-filename": "percent-encoding-2.1.0.crate"
+        "dest": "cargo/vendor/percent-encoding-2.1.0"
     },
     {
         "type": "file",
@@ -922,11 +922,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-project/pin-project-0.4.23.crate",
         "sha256": "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa",
-        "dest": "cargo/vendor",
-        "dest-filename": "pin-project-0.4.23.crate"
+        "dest": "cargo/vendor/pin-project-0.4.23"
     },
     {
         "type": "file",
@@ -935,11 +935,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-0.4.23.crate",
         "sha256": "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f",
-        "dest": "cargo/vendor",
-        "dest-filename": "pin-project-internal-0.4.23.crate"
+        "dest": "cargo/vendor/pin-project-internal-0.4.23"
     },
     {
         "type": "file",
@@ -948,11 +948,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.1.7.crate",
         "sha256": "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715",
-        "dest": "cargo/vendor",
-        "dest-filename": "pin-project-lite-0.1.7.crate"
+        "dest": "cargo/vendor/pin-project-lite-0.1.7"
     },
     {
         "type": "file",
@@ -961,11 +961,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-utils/pin-utils-0.1.0.crate",
         "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
-        "dest": "cargo/vendor",
-        "dest-filename": "pin-utils-0.1.0.crate"
+        "dest": "cargo/vendor/pin-utils-0.1.0"
     },
     {
         "type": "file",
@@ -974,11 +974,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.18.crate",
         "sha256": "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33",
-        "dest": "cargo/vendor",
-        "dest-filename": "pkg-config-0.3.18.crate"
+        "dest": "cargo/vendor/pkg-config-0.3.18"
     },
     {
         "type": "file",
@@ -987,11 +987,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.8.crate",
         "sha256": "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea",
-        "dest": "cargo/vendor",
-        "dest-filename": "ppv-lite86-0.2.8.crate"
+        "dest": "cargo/vendor/ppv-lite86-0.2.8"
     },
     {
         "type": "file",
@@ -1000,11 +1000,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.19.crate",
         "sha256": "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12",
-        "dest": "cargo/vendor",
-        "dest-filename": "proc-macro2-1.0.19.crate"
+        "dest": "cargo/vendor/proc-macro2-1.0.19"
     },
     {
         "type": "file",
@@ -1013,11 +1013,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/quote/quote-1.0.7.crate",
         "sha256": "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37",
-        "dest": "cargo/vendor",
-        "dest-filename": "quote-1.0.7.crate"
+        "dest": "cargo/vendor/quote-1.0.7"
     },
     {
         "type": "file",
@@ -1026,11 +1026,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand/rand-0.7.3.crate",
         "sha256": "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand-0.7.3.crate"
+        "dest": "cargo/vendor/rand-0.7.3"
     },
     {
         "type": "file",
@@ -1039,11 +1039,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.2.2.crate",
         "sha256": "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_chacha-0.2.2.crate"
+        "dest": "cargo/vendor/rand_chacha-0.2.2"
     },
     {
         "type": "file",
@@ -1052,11 +1052,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_core/rand_core-0.5.1.crate",
         "sha256": "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_core-0.5.1.crate"
+        "dest": "cargo/vendor/rand_core-0.5.1"
     },
     {
         "type": "file",
@@ -1065,11 +1065,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_hc/rand_hc-0.2.0.crate",
         "sha256": "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_hc-0.2.0.crate"
+        "dest": "cargo/vendor/rand_hc-0.2.0"
     },
     {
         "type": "file",
@@ -1078,11 +1078,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rayon/rayon-1.4.1.crate",
         "sha256": "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032",
-        "dest": "cargo/vendor",
-        "dest-filename": "rayon-1.4.1.crate"
+        "dest": "cargo/vendor/rayon-1.4.1"
     },
     {
         "type": "file",
@@ -1091,11 +1091,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rayon-core/rayon-core-1.8.1.crate",
         "sha256": "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf",
-        "dest": "cargo/vendor",
-        "dest-filename": "rayon-core-1.8.1.crate"
+        "dest": "cargo/vendor/rayon-core-1.8.1"
     },
     {
         "type": "file",
@@ -1104,11 +1104,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.1.57.crate",
         "sha256": "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce",
-        "dest": "cargo/vendor",
-        "dest-filename": "redox_syscall-0.1.57.crate"
+        "dest": "cargo/vendor/redox_syscall-0.1.57"
     },
     {
         "type": "file",
@@ -1117,11 +1117,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/remove_dir_all/remove_dir_all-0.5.3.crate",
         "sha256": "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7",
-        "dest": "cargo/vendor",
-        "dest-filename": "remove_dir_all-0.5.3.crate"
+        "dest": "cargo/vendor/remove_dir_all-0.5.3"
     },
     {
         "type": "file",
@@ -1130,11 +1130,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/remove_dir_all/remove_dir_all-0.6.0.crate",
         "sha256": "3f43c8c593a759eb8eae137a1ad7b9ed881453a942ac3ce58b87b6e5c2364779",
-        "dest": "cargo/vendor",
-        "dest-filename": "remove_dir_all-0.6.0.crate"
+        "dest": "cargo/vendor/remove_dir_all-0.6.0"
     },
     {
         "type": "file",
@@ -1143,11 +1143,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/reqwest/reqwest-0.10.7.crate",
         "sha256": "12427a5577082c24419c9c417db35cfeb65962efc7675bb6b0d5f1f9d315bfe6",
-        "dest": "cargo/vendor",
-        "dest-filename": "reqwest-0.10.7.crate"
+        "dest": "cargo/vendor/reqwest-0.10.7"
     },
     {
         "type": "file",
@@ -1156,11 +1156,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rmp/rmp-0.8.9.crate",
         "sha256": "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f",
-        "dest": "cargo/vendor",
-        "dest-filename": "rmp-0.8.9.crate"
+        "dest": "cargo/vendor/rmp-0.8.9"
     },
     {
         "type": "file",
@@ -1169,11 +1169,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rmp-serde/rmp-serde-0.14.4.crate",
         "sha256": "4ce7d70c926fe472aed493b902010bccc17fa9f7284145cb8772fd22fdb052d8",
-        "dest": "cargo/vendor",
-        "dest-filename": "rmp-serde-0.14.4.crate"
+        "dest": "cargo/vendor/rmp-serde-0.14.4"
     },
     {
         "type": "file",
@@ -1182,11 +1182,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ryu/ryu-1.0.5.crate",
         "sha256": "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e",
-        "dest": "cargo/vendor",
-        "dest-filename": "ryu-1.0.5.crate"
+        "dest": "cargo/vendor/ryu-1.0.5"
     },
     {
         "type": "file",
@@ -1195,11 +1195,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/schannel/schannel-0.1.19.crate",
         "sha256": "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75",
-        "dest": "cargo/vendor",
-        "dest-filename": "schannel-0.1.19.crate"
+        "dest": "cargo/vendor/schannel-0.1.19"
     },
     {
         "type": "file",
@@ -1208,11 +1208,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.1.0.crate",
         "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
-        "dest": "cargo/vendor",
-        "dest-filename": "scopeguard-1.1.0.crate"
+        "dest": "cargo/vendor/scopeguard-1.1.0"
     },
     {
         "type": "file",
@@ -1221,11 +1221,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/security-framework/security-framework-0.4.4.crate",
         "sha256": "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535",
-        "dest": "cargo/vendor",
-        "dest-filename": "security-framework-0.4.4.crate"
+        "dest": "cargo/vendor/security-framework-0.4.4"
     },
     {
         "type": "file",
@@ -1234,11 +1234,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/security-framework-sys/security-framework-sys-0.4.3.crate",
         "sha256": "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405",
-        "dest": "cargo/vendor",
-        "dest-filename": "security-framework-sys-0.4.3.crate"
+        "dest": "cargo/vendor/security-framework-sys-0.4.3"
     },
     {
         "type": "file",
@@ -1247,11 +1247,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde/serde-1.0.114.crate",
         "sha256": "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde-1.0.114.crate"
+        "dest": "cargo/vendor/serde-1.0.114"
     },
     {
         "type": "file",
@@ -1260,11 +1260,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_bytes/serde_bytes-0.11.5.crate",
         "sha256": "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_bytes-0.11.5.crate"
+        "dest": "cargo/vendor/serde_bytes-0.11.5"
     },
     {
         "type": "file",
@@ -1273,11 +1273,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.114.crate",
         "sha256": "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_derive-1.0.114.crate"
+        "dest": "cargo/vendor/serde_derive-1.0.114"
     },
     {
         "type": "file",
@@ -1286,11 +1286,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.57.crate",
         "sha256": "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_json-1.0.57.crate"
+        "dest": "cargo/vendor/serde_json-1.0.57"
     },
     {
         "type": "file",
@@ -1299,11 +1299,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_repr/serde_repr-0.1.6.crate",
         "sha256": "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_repr-0.1.6.crate"
+        "dest": "cargo/vendor/serde_repr-0.1.6"
     },
     {
         "type": "file",
@@ -1312,11 +1312,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_urlencoded/serde_urlencoded-0.6.1.crate",
         "sha256": "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_urlencoded-0.6.1.crate"
+        "dest": "cargo/vendor/serde_urlencoded-0.6.1"
     },
     {
         "type": "file",
@@ -1325,11 +1325,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/slab/slab-0.4.2.crate",
         "sha256": "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8",
-        "dest": "cargo/vendor",
-        "dest-filename": "slab-0.4.2.crate"
+        "dest": "cargo/vendor/slab-0.4.2"
     },
     {
         "type": "file",
@@ -1338,11 +1338,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/socket2/socket2-0.3.12.crate",
         "sha256": "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918",
-        "dest": "cargo/vendor",
-        "dest-filename": "socket2-0.3.12.crate"
+        "dest": "cargo/vendor/socket2-0.3.12"
     },
     {
         "type": "file",
@@ -1351,11 +1351,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/sodiumoxide/sodiumoxide-0.2.6.crate",
         "sha256": "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8",
-        "dest": "cargo/vendor",
-        "dest-filename": "sodiumoxide-0.2.6.crate"
+        "dest": "cargo/vendor/sodiumoxide-0.2.6"
     },
     {
         "type": "file",
@@ -1364,11 +1364,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/strsim/strsim-0.8.0.crate",
         "sha256": "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a",
-        "dest": "cargo/vendor",
-        "dest-filename": "strsim-0.8.0.crate"
+        "dest": "cargo/vendor/strsim-0.8.0"
     },
     {
         "type": "file",
@@ -1377,11 +1377,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/syn/syn-1.0.36.crate",
         "sha256": "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250",
-        "dest": "cargo/vendor",
-        "dest-filename": "syn-1.0.36.crate"
+        "dest": "cargo/vendor/syn-1.0.36"
     },
     {
         "type": "file",
@@ -1390,11 +1390,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tempfile/tempfile-3.1.0.crate",
         "sha256": "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9",
-        "dest": "cargo/vendor",
-        "dest-filename": "tempfile-3.1.0.crate"
+        "dest": "cargo/vendor/tempfile-3.1.0"
     },
     {
         "type": "file",
@@ -1403,11 +1403,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/textwrap/textwrap-0.11.0.crate",
         "sha256": "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060",
-        "dest": "cargo/vendor",
-        "dest-filename": "textwrap-0.11.0.crate"
+        "dest": "cargo/vendor/textwrap-0.11.0"
     },
     {
         "type": "file",
@@ -1416,11 +1416,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/time/time-0.1.43.crate",
         "sha256": "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438",
-        "dest": "cargo/vendor",
-        "dest-filename": "time-0.1.43.crate"
+        "dest": "cargo/vendor/time-0.1.43"
     },
     {
         "type": "file",
@@ -1429,11 +1429,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tinyvec/tinyvec-0.3.3.crate",
         "sha256": "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed",
-        "dest": "cargo/vendor",
-        "dest-filename": "tinyvec-0.3.3.crate"
+        "dest": "cargo/vendor/tinyvec-0.3.3"
     },
     {
         "type": "file",
@@ -1442,11 +1442,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio/tokio-0.2.22.crate",
         "sha256": "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-0.2.22.crate"
+        "dest": "cargo/vendor/tokio-0.2.22"
     },
     {
         "type": "file",
@@ -1455,11 +1455,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-tls/tokio-tls-0.3.1.crate",
         "sha256": "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-tls-0.3.1.crate"
+        "dest": "cargo/vendor/tokio-tls-0.3.1"
     },
     {
         "type": "file",
@@ -1468,11 +1468,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-util/tokio-util-0.3.1.crate",
         "sha256": "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-util-0.3.1.crate"
+        "dest": "cargo/vendor/tokio-util-0.3.1"
     },
     {
         "type": "file",
@@ -1481,11 +1481,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/toml/toml-0.5.6.crate",
         "sha256": "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a",
-        "dest": "cargo/vendor",
-        "dest-filename": "toml-0.5.6.crate"
+        "dest": "cargo/vendor/toml-0.5.6"
     },
     {
         "type": "file",
@@ -1494,11 +1494,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tower-service/tower-service-0.3.0.crate",
         "sha256": "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860",
-        "dest": "cargo/vendor",
-        "dest-filename": "tower-service-0.3.0.crate"
+        "dest": "cargo/vendor/tower-service-0.3.0"
     },
     {
         "type": "file",
@@ -1507,11 +1507,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing/tracing-0.1.17.crate",
         "sha256": "dbdf4ccd1652592b01286a5dbe1e2a77d78afaa34beadd9872a5f7396f92aaa9",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-0.1.17.crate"
+        "dest": "cargo/vendor/tracing-0.1.17"
     },
     {
         "type": "file",
@@ -1520,11 +1520,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.11.crate",
         "sha256": "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-core-0.1.11.crate"
+        "dest": "cargo/vendor/tracing-core-0.1.11"
     },
     {
         "type": "file",
@@ -1533,11 +1533,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/try-lock/try-lock-0.2.3.crate",
         "sha256": "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642",
-        "dest": "cargo/vendor",
-        "dest-filename": "try-lock-0.2.3.crate"
+        "dest": "cargo/vendor/try-lock-0.2.3"
     },
     {
         "type": "file",
@@ -1546,11 +1546,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicase/unicase-2.6.0.crate",
         "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicase-2.6.0.crate"
+        "dest": "cargo/vendor/unicase-2.6.0"
     },
     {
         "type": "file",
@@ -1559,11 +1559,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.4.crate",
         "sha256": "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-bidi-0.3.4.crate"
+        "dest": "cargo/vendor/unicode-bidi-0.3.4"
     },
     {
         "type": "file",
@@ -1572,11 +1572,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.13.crate",
         "sha256": "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-normalization-0.1.13.crate"
+        "dest": "cargo/vendor/unicode-normalization-0.1.13"
     },
     {
         "type": "file",
@@ -1585,11 +1585,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.6.0.crate",
         "sha256": "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-segmentation-1.6.0.crate"
+        "dest": "cargo/vendor/unicode-segmentation-1.6.0"
     },
     {
         "type": "file",
@@ -1598,11 +1598,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.1.8.crate",
         "sha256": "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-width-0.1.8.crate"
+        "dest": "cargo/vendor/unicode-width-0.1.8"
     },
     {
         "type": "file",
@@ -1611,11 +1611,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.1.crate",
         "sha256": "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-xid-0.2.1.crate"
+        "dest": "cargo/vendor/unicode-xid-0.2.1"
     },
     {
         "type": "file",
@@ -1624,11 +1624,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/url/url-2.1.1.crate",
         "sha256": "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb",
-        "dest": "cargo/vendor",
-        "dest-filename": "url-2.1.1.crate"
+        "dest": "cargo/vendor/url-2.1.1"
     },
     {
         "type": "file",
@@ -1637,11 +1637,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/vcpkg/vcpkg-0.2.10.crate",
         "sha256": "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c",
-        "dest": "cargo/vendor",
-        "dest-filename": "vcpkg-0.2.10.crate"
+        "dest": "cargo/vendor/vcpkg-0.2.10"
     },
     {
         "type": "file",
@@ -1650,11 +1650,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/vec_map/vec_map-0.8.2.crate",
         "sha256": "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191",
-        "dest": "cargo/vendor",
-        "dest-filename": "vec_map-0.8.2.crate"
+        "dest": "cargo/vendor/vec_map-0.8.2"
     },
     {
         "type": "file",
@@ -1663,11 +1663,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/version_check/version_check-0.9.2.crate",
         "sha256": "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed",
-        "dest": "cargo/vendor",
-        "dest-filename": "version_check-0.9.2.crate"
+        "dest": "cargo/vendor/version_check-0.9.2"
     },
     {
         "type": "file",
@@ -1676,11 +1676,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/want/want-0.3.0.crate",
         "sha256": "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0",
-        "dest": "cargo/vendor",
-        "dest-filename": "want-0.3.0.crate"
+        "dest": "cargo/vendor/want-0.3.0"
     },
     {
         "type": "file",
@@ -1689,11 +1689,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasi/wasi-0.9.0+wasi-snapshot-preview1.crate",
         "sha256": "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasi-0.9.0+wasi-snapshot-preview1.crate"
+        "dest": "cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1"
     },
     {
         "type": "file",
@@ -1702,11 +1702,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.65.crate",
         "sha256": "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-0.2.65.crate"
+        "dest": "cargo/vendor/wasm-bindgen-0.2.65"
     },
     {
         "type": "file",
@@ -1715,11 +1715,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.65.crate",
         "sha256": "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-backend-0.2.65.crate"
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.65"
     },
     {
         "type": "file",
@@ -1728,11 +1728,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.15.crate",
         "sha256": "41ad6e4e8b2b7f8c90b6e09a9b590ea15cb0d1dbe28502b5a405cd95d1981671",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-futures-0.4.15.crate"
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.15"
     },
     {
         "type": "file",
@@ -1741,11 +1741,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.65.crate",
         "sha256": "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-macro-0.2.65.crate"
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.65"
     },
     {
         "type": "file",
@@ -1754,11 +1754,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.65.crate",
         "sha256": "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-macro-support-0.2.65.crate"
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.65"
     },
     {
         "type": "file",
@@ -1767,11 +1767,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.65.crate",
         "sha256": "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-shared-0.2.65.crate"
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.65"
     },
     {
         "type": "file",
@@ -1780,11 +1780,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.42.crate",
         "sha256": "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2",
-        "dest": "cargo/vendor",
-        "dest-filename": "web-sys-0.3.42.crate"
+        "dest": "cargo/vendor/web-sys-0.3.42"
     },
     {
         "type": "file",
@@ -1793,11 +1793,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi/winapi-0.2.8.crate",
         "sha256": "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-0.2.8.crate"
+        "dest": "cargo/vendor/winapi-0.2.8"
     },
     {
         "type": "file",
@@ -1806,11 +1806,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
         "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-0.3.9.crate"
+        "dest": "cargo/vendor/winapi-0.3.9"
     },
     {
         "type": "file",
@@ -1819,11 +1819,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-build/winapi-build-0.1.1.crate",
         "sha256": "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-build-0.1.1.crate"
+        "dest": "cargo/vendor/winapi-build-0.1.1"
     },
     {
         "type": "file",
@@ -1832,11 +1832,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
         "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-i686-pc-windows-gnu-0.4.0.crate"
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
     },
     {
         "type": "file",
@@ -1845,11 +1845,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
         "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-x86_64-pc-windows-gnu-0.4.0.crate"
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
     },
     {
         "type": "file",
@@ -1858,11 +1858,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winreg/winreg-0.7.0.crate",
         "sha256": "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69",
-        "dest": "cargo/vendor",
-        "dest-filename": "winreg-0.7.0.crate"
+        "dest": "cargo/vendor/winreg-0.7.0"
     },
     {
         "type": "file",
@@ -1871,11 +1871,11 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ws2_32-sys/ws2_32-sys-0.2.1.crate",
         "sha256": "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e",
-        "dest": "cargo/vendor",
-        "dest-filename": "ws2_32-sys-0.2.1.crate"
+        "dest": "cargo/vendor/ws2_32-sys-0.2.1"
     },
     {
         "type": "file",
@@ -1884,15 +1884,8 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "shell",
-        "dest": "cargo/vendor",
-        "commands": [
-            "for c in *.crate; do tar -xf $c; done"
-        ]
-    },
-    {
         "type": "file",
-        "url": "data:%5Bsource.vendored-sources%5D%0Adirectory%20%3D%20%22cargo/vendor%22%0A%0A%5Bsource.crates-io%5D%0Areplace-with%20%3D%20%22vendored-sources%22%0A%0A%5Bsource.%22https%3A//github.com/etesync/etebase-rs%22%5D%0Agit%20%3D%20%22https%3A//github.com/etesync/etebase-rs%22%0Areplace-with%20%3D%20%22vendored-sources%22%0Arev%20%3D%20%22b3aad3e01fd602f3547e0af82d3bf1b5701b79a2%22%0A",
+        "url": "data:%5Bsource.vendored-sources%5D%0Adirectory%20%3D%20%22cargo/vendor%22%0A%0A%5Bsource.crates-io%5D%0Areplace-with%20%3D%20%22vendored-sources%22%0A%0A%5Bsource.%22https%3A//github.com/etesync/etebase-rs%22%5D%0Agit%20%3D%20%22https%3A//github.com/etesync/etebase-rs%22%0Areplace-with%20%3D%20%22vendored-sources%22%0Arev%20%3D%20%22a56a3bac2c056b957cbb5d81e1f70815da66bd9a%22%0A",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/org.gnome.Evolution.json
+++ b/org.gnome.Evolution.json
@@ -459,8 +459,8 @@
                 "sources": [
                     {
                         "type": "archive",
-                        "url": "https://github.com/etesync/libetebase/archive/v0.4.1.tar.gz",
-                        "sha256": "ac8a64c16d2233a53cb97866ca8e2cf154c02622584676a90170e91e5fc3af08",
+                        "url": "https://github.com/etesync/libetebase/archive/v0.5.0.tar.gz",
+                        "sha256": "448f677bd24bb4315d0d29ae95f29b7841cb64c0af049952ecb634ab683eea9c",
                         "x-checker-data": {
                             "type": "anitya",
                             "project-id": 235050,


### PR DESCRIPTION
libetebase-cargo-sources.json has been updated using [flatpak-cargo-generator.py](https://github.com/flatpak/flatpak-builder-tools/blob/master/cargo/flatpak-cargo-generator.py)