### PR TITLE
Remove extraneous parenthesis

### DIFF
--- a/org.gnome.Evolution.json
+++ b/org.gnome.Evolution.json
@@ -328,7 +328,7 @@
 					"type": "shell",
 					"commands": [
 						"cp config.h.in config.h.in.orig",
-						"cat config.h.in.orig | sed -e \"s|\\@VERSION_SUBSTRING\\@| \\(by Flathub.org)\\)|\" >config.h.in",
+						"cat config.h.in.orig | sed -e \"s|\\@VERSION_SUBSTRING\\@| \\(by Flathub.org\\)|\" >config.h.in",
 						"cp data/org.gnome.Evolution.appdata.xml.in.in data/org.gnome.Evolution.appdata.xml.in.in.orig",
 						"cat data/org.gnome.Evolution.appdata.xml.in.in.orig | sed -e \"s|\\@APPDATA_RELEASES\\@|APPDATA_RELEASES|\" >data/org.gnome.Evolution.appdata.xml.in.in"
 					]


### PR DESCRIPTION
This change removes an extraneous paren from the about window — note below in the image the trailing close paren "3.44.1 (by Flathub.org)**)**" .

![Screenshot from 2022-06-08 18-25-09](https://user-images.githubusercontent.com/275221/172575624-6085cbe0-0593-4113-a33a-911d5e64f4a7.png)
