### PR TITLE
Add --filesystem=xdg-run/gvfsd:rw

### DIFF
--- a/org.gnome.Evolution.json
+++ b/org.gnome.Evolution.json
@@ -39,7 +39,8 @@
             "--filesystem=~/.gnupg:rw",
             "--filesystem=xdg-config/gnupg:rw",
             "--filesystem=~/.pki:rw",
-            "--filesystem=xdg-config/pki:rw"
+            "--filesystem=xdg-config/pki:rw",
+            "--filesystem=xdg-run/gvfsd:rw"
         ],
         "modules": [
             "shared-modules/libcanberra/libcanberra.json",
@@ -60,7 +61,7 @@
                         "type": "archive",
                         "url": "https://github.com/libical/libical/releases/download/v3.0.14/libical-3.0.14.tar.gz",
                         "sha256": "4284b780356f1dc6a01f16083e7b836e63d3815e27ed0eaaad684712357ccc8f"
-                     }   
+                     }
                 ]
             },
 
@@ -78,7 +79,7 @@
 				}
 			]
             },
-          
+
             {
                 "name": "liboauth",
                 "config-opts": [ "--enable-nss" ],
@@ -91,15 +92,15 @@
                     }
                 ]
             },
-     
+
             {
                 "name": "gnome-online-accounts",
-                "config-opts": 
+                "config-opts":
 		[
                     "--disable-Werror",
                     "--disable-telepathy",
                     "--disable-documentation",
-                    "--disable-backend" 
+                    "--disable-backend"
 		],
                 "cleanup": [ "/bin", "/share/GConf" ],
                 "sources": [
@@ -110,7 +111,7 @@
                     }
                 ]
             },
-     
+
             {
                 "name": "libgdata",
                 "buildsystem": "meson",
@@ -132,7 +133,7 @@
                     }
                 ]
             },
-     
+
             {
                 "name": "geocode-glib",
                 "buildsystem": "meson",
@@ -151,7 +152,7 @@
                     }
                 ]
             },
-     
+
             {
                 "name": "libgweather",
                 "buildsystem": "meson",
@@ -166,7 +167,7 @@
                     }
                 ]
             },
-     
+
             {
                 "name": "openldap",
                 "rm-configure": true,
@@ -189,7 +190,7 @@
                         "url": "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.2.tgz",
                         "sha256": "81d09345232eb62486ecf5acacd2c56c0c45b4a6c8c066612e7f421a23a1cf87"
                     },
-     
+
                     {
                         "type": "script",
                         "dest-filename": "autogen.sh",
@@ -198,7 +199,7 @@
                         ]
                     }
                 ]
-            }, 
+            },
 
             "shared-modules/intltool/intltool-0.51.json",
 
@@ -274,7 +275,7 @@
 				}
 			]
 		},
-		
+
 	    {
 			"name": "cmark",
 			"buildsystem": "cmake-ninja",
@@ -292,7 +293,7 @@
 				}
 			]
 		},
-     
+
             {
                 "name": "evolution",
                 "buildsystem": "cmake-ninja",
@@ -404,7 +405,7 @@
 				"cp flatpak-evolution-wrapper.sh /app/bin/evolution"
 			]
 		},
-     
+
              {
 			"name": "news-to-appdata",
 			"buildsystem": "simple",
@@ -439,7 +440,7 @@
 				"./update-appdata.sh stable"
 			]
 		},
-      
+
             {
                 "name": "libmspack",
                 "cleanup": [ "/bin" ],
@@ -451,7 +452,7 @@
                     }
                 ]
             },
-     
+
             {
                 "name": "evolution-ews",
                 "buildsystem": "cmake-ninja",
@@ -460,13 +461,13 @@
                         "type": "archive",
                         "url": "https://download.gnome.org/sources/evolution-ews/3.44/evolution-ews-3.44.3.tar.xz",
                         "sha256": "85ccaca2887af85bf048e473c7b6c42c5f5641ab05a5bc4cfcea34e2b6f5be17"
-                    }    
+                    }
                     ],
                 "post-install": [
 				"cp NEWS /app/share/NEWS.ews"
                 ]
             },
-            
+
             {
                 "name": "libetebase",
                 "buildsystem": "simple",
@@ -513,8 +514,8 @@
             	    	"type": "archive",
             	    	"url": "https://download.gnome.org/sources/libsecret/0.19/libsecret-0.19.1.tar.xz",
             	    	"sha256": "8583e10179456ae2c83075d95455f156dc08db6278b32bf4bd61819335a30e3a"
-            	    }	
+            	    }
         	]
 	}
 	]
-}	
+}


### PR DESCRIPTION
I'm not sure if there are reasons not to add this, just proposing in case it was missed accidentally.

Without this, on Fedora 36 at least, the following warning appears when clicking a link in a mail to open in a browser:

> (evolution.bin:25): GVFS-WARNING **: 10:27:18.223: The peer-to-peer connection failed: Permission denied. Falling back to the session bus. Your application is probably missing --filesystem=xdg-run/gvfsd privileges.

It might just be me, but it seems like with this, links open slightly snappier too.