### PR TITLE
Enable Flatpak extensions

### DIFF
--- a/org.gnome.Evolution.Extension.evolution-etesync.json
+++ b/org.gnome.Evolution.Extension.evolution-etesync.json
@@ -1,0 +1,77 @@
+{
+	"id": "org.gnome.Evolution.Extension.evolution-etesync",
+	"runtime": "org.gnome.Evolution",
+	"branch": "stable",
+	"runtime-version": "master",
+	"sdk": "org.gnome.Sdk//43",
+        "sdk-extensions" : [
+            "org.freedesktop.Sdk.Extension.rust-stable"
+        ],
+	"build-extension": true,
+	"separate-locales": false,
+	"appstream-compose": false,
+	"finish-args": [],
+	"build-options" : {
+		"prefix": "/app/evolution/extensions/evolution-etesync",
+		"prepend-path": "/app/evolution/extensions/evolution-etesync",
+		"prepend-pkg-config-path": "/app/evolution/extensions/evolution-etesync/lib/pkgconfig",
+		"append-path": "/usr/lib/sdk/rust-stable/bin",
+		"cflags": "-O2 -g -Wno-deprecated-declarations",
+		"cxxflags": "-O2 -g -Wno-deprecated-declarations"
+	},
+        "cleanup": [
+            "/include",
+            "/lib/cmake",
+            "/lib/pkgconfig",
+            "/share/pkgconfig",
+            "/share/aclocal",
+            "*.la",
+            "*.a"
+        ],
+	"modules": [
+		{
+			"name": "libetebase",
+			"buildsystem": "simple",
+			"build-commands": [
+				"mkdir .cargo",
+				"cp cargo/config .cargo/",
+				"mv libetebase-Cargo.lock Cargo.lock",
+				"cargo --offline fetch --manifest-path Cargo.toml",
+				"cargo --offline build --release",
+				"PREFIX=/app/evolution/extensions/evolution-etesync make V=1 VERBOSE=1 pkgconfig",
+				"PREFIX=/app/evolution/extensions/evolution-etesync make V=1 VERBOSE=1 install",
+				"mv /app/evolution/extensions/evolution-etesync/lib/libetebase.so /app/evolution/extensions/evolution-etesync/lib/libetebase.so.0",
+				"ln -s /app/evolution/extensions/evolution-etesync/lib/libetebase.so.0 /app/evolution/extensions/evolution-etesync/lib/libetebase.so"
+			],
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://github.com/etesync/libetebase/archive/v0.5.3.tar.gz",
+					"sha256": "78c79f72df40ae4ed85beca593d870159f923e8b9e0111c16e34b6142c634995"
+				},
+				{
+					"type": "file",
+					"path": "libetebase-Cargo.lock"
+				},
+				"libetebase-cargo-sources.json"
+			]
+		},
+
+		"shared-modules/intltool/intltool-0.51.json",
+
+		{
+			"name": "evolution-etesync",
+			"buildsystem": "cmake-ninja",
+			"config-opts": [
+				"-DFORCE_INSTALL_PREFIX=/app/evolution/extensions/evolution-etesync"
+			],
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://download.gnome.org/sources/evolution-etesync/1.1/evolution-etesync-1.1.0.tar.xz",
+					"sha256": "b8202e697741f774da17209689eef5b983b8a7e8b4c545552836539e5745e043"
+				}
+			]
+		}
+	]
+}

--- a/org.gnome.Evolution.json
+++ b/org.gnome.Evolution.json
@@ -15,11 +15,6 @@
             "cxxflags": "-O2 -g -Wno-deprecated-declarations"
         },
         "cleanup": [
-            "/include",
-            "/lib/cmake",
-            "/lib/pkgconfig",
-            "/share/pkgconfig",
-            "/share/aclocal",
             "*.la",
             "*.a"
         ],
@@ -43,6 +38,16 @@
             "--filesystem=xdg-config/pki:rw",
             "--filesystem=xdg-run/gvfsd:rw"
         ],
+	"add-extensions": {
+		"org.gnome.Evolution.Extension": {
+			"directory": "evolution/extensions",
+			"add-ld-path": "lib",
+			"merge-dirs": "lib;share",
+			"subdirectories": true,
+			"no-autodownload": true,
+			"autodelete": true
+		}
+	},
         "modules": [
             "shared-modules/libcanberra/libcanberra.json",
             {
@@ -209,6 +214,7 @@
                 "cleanup": [ "/share/GConf" ],
                 "config-opts": [
                     "-DDBUS_SERVICES_PREFIX=org.gnome.Evolution",
+                    "-DEXTENSIONS_DIR=/app/evolution/extensions",
                     "-DENABLE_FILE_LOCKING=fcntl",
                     "-DENABLE_DOT_LOCKING=OFF",
                     "-DENABLE_OAUTH2=ON",
@@ -234,6 +240,7 @@
                     }
                 ],
                 "post-install": [
+				"install -d /app/evolution/extensions",
 				"cp NEWS /app/share/NEWS.eds"
 			]
 

--- a/org.gnome.Evolution.json
+++ b/org.gnome.Evolution.json
@@ -3,14 +3,10 @@
         "runtime": "org.gnome.Platform",
         "runtime-version": "43",
         "sdk": "org.gnome.Sdk",
-        "sdk-extensions" : [
-            "org.freedesktop.Sdk.Extension.rust-stable"
-        ],
         "command": "evolution",
         "rename-icon": "evolution",
         "copy-icon": true,
         "build-options" : {
-            "append-path": "/usr/lib/sdk/rust-stable/bin",
             "cflags": "-O2 -g -Wno-deprecated-declarations",
             "cxxflags": "-O2 -g -Wno-deprecated-declarations"
         },
@@ -476,45 +472,6 @@
 				"./update-appdata.sh stable"
 			]
 		},
-		
-		{
-                "name": "libetebase",
-                "buildsystem": "simple",
-                "build-commands": [
-                    "mkdir .cargo",
-                    "cp cargo/config .cargo/",
-                    "mv libetebase-Cargo.lock Cargo.lock",
-                    "cargo --offline fetch --manifest-path Cargo.toml",
-                    "cargo --offline build --release",
-                    "PREFIX=/app make V=1 VERBOSE=1 pkgconfig",
-                    "PREFIX=/app make V=1 VERBOSE=1 install",
-                    "mv /app/lib/libetebase.so /app/lib/libetebase.so.0",
-                    "ln -s /app/lib/libetebase.so.0 /app/lib/libetebase.so"
-                ],
-                "sources": [
-                    {
-                        "type": "archive",
-                        "url": "https://github.com/etesync/libetebase/archive/v0.5.3.tar.gz",
-                        "sha256": "78c79f72df40ae4ed85beca593d870159f923e8b9e0111c16e34b6142c634995"
-                    },
-                    {
-                        "type": "file",
-                        "path": "libetebase-Cargo.lock"
-                    },
-                    "libetebase-cargo-sources.json"
-                ]
-            },
-            {
-                "name": "evolution-etesync",
-                "buildsystem": "cmake-ninja",
-                "sources": [
-                    {
-                        "type": "archive",
-                        "url": "https://download.gnome.org/sources/evolution-etesync/1.1/evolution-etesync-1.1.0.tar.xz",
-                        "sha256": "b8202e697741f774da17209689eef5b983b8a7e8b4c545552836539e5745e043"
-                    }
-                ]
-            },
 
             {
             	"name": "libsecret",


### PR DESCRIPTION
_This is a new take of the https://github.com/flathub/org.gnome.Evolution/pull/101_

Since upstream commit https://gitlab.gnome.org/GNOME/evolution-data-server/-/commit/4862be52c8a156b44897270a82cac0646748c3ec the evolution(-data-server) supports out-of-tree extensions, which can be used in Flatpak.

Here are necessary changes to make it work and the evolution-etesync is chosen as an example of such extension. I do not know how it works here, maybe you'd need a new (sub)project in GitHub to have it built.

The evolution-ews can be extracted out too, but, I think, especially due to its lightweight dependencies and possibly larger user base, it can stay bundled. It is part of the release changes too, which won't be possible when it's an extension.

Also, I do not know how it works with respect of the appstream data (how the extension exports an information about itself in a usable form for for example gnome-software). I wasn't able to verify it locally.
