### PR TITLE
Restore version information about the source being Flathub.org

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+  #  branches: [main, beta]
+  pull_request:
+name: CI
+jobs:
+  verify-version:
+    name: "Verify version string"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v4
+    - run: |
+        if [ `cat org.gnome.Evolution.json | grep -- "-DVERSION_SUBSTRING" | grep -c "by Flathub.org"` = "0" ]; then
+            echo "ERROR: Version information broken, VERSION_SUBSTRING should contain 'by Flathub.org'" >&2;
+            exit 1;
+        fi
+    - run: |
+        if [ `cat org.gnome.Evolution.json | grep -- "@VERSION_SUBSTRING" | grep -c "by Flathub.org"` = "0" ]; then
+            echo "ERROR: Version information broken, VERSION_SUBSTRING should contain 'by Flathub.org'" >&2;
+            exit 1;
+        fi

--- a/org.gnome.Evolution.json
+++ b/org.gnome.Evolution.json
@@ -346,7 +346,7 @@
 					"type": "shell",
 					"commands": [
 						"cp config.h.in config.h.in.orig",
-						"cat config.h.in.orig | sed -e \"s|\\@VERSION_SUBSTRING\\@| \\(flatpak git$(git log --pretty=format:%h --max-count=1)\\)|\" >config.h.in",
+						"cat config.h.in.orig | sed -e \"s|\\@VERSION_SUBSTRING\\@| \\(by Flathub.org\\)|\" >config.h.in",
 						"cp data/org.gnome.Evolution.metainfo.xml.in.in data/org.gnome.Evolution.metainfo.xml.in.in.orig",
 						"cat data/org.gnome.Evolution.metainfo.xml.in.in.orig | sed -e \"s|\\@APPDATA_RELEASES\\@|APPDATA_RELEASES|\" >data/org.gnome.Evolution.metainfo.xml.in.in"
 					]


### PR DESCRIPTION
Accidentally removed in https://github.com/flathub/org.gnome.Evolution/commit/4c7b9f4cc7fdd5c72dbbc142580d0240c4cbd802

Cherry-pick to `beta` too, I guess.

How do you run CI here, please? I would add there a test for it, like:
```sh
#!/bin/bash
if [ `flatpak run org.gnome.Evolution --version | grep -c "by Flathub.org"` = "0" ]; then
    echo "ERROR: Version information broken, should contain 'by Flathub.org'" >&2;
    exit 1;
fi
```
to avoid these accidents in the future.